### PR TITLE
Investigate speed control warning in Mads mode

### DIFF
--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -71,7 +71,7 @@ class Car:
 
   def __init__(self, CI=None, RI=None) -> None:
     self.can_sock = messaging.sub_sock('can', timeout=20)
-    self.sm = messaging.SubMaster(['pandaStates', 'carControl', 'onroadEvents'] + ['carControlSP'])
+    self.sm = messaging.SubMaster(['pandaStates', 'carControl', 'onroadEvents'] + ['carControlSP', 'selfdriveStateSP'])
     self.pm = messaging.PubMaster(['sendcan', 'carState', 'carParams', 'carOutput', 'liveTracks'] + ['carParamsSP', 'carStateSP'])
 
     self.can_rcv_cum_timeout_counter = 0
@@ -216,7 +216,11 @@ class Car:
     if can_rcv_valid and REPLAY:
       self.can_log_mono_time = messaging.log_from_bytes(can_strs[0]).logMonoTime
 
-    self.v_cruise_helper.update_v_cruise(CS, self.sm['carControl'].enabled, self.is_metric)
+    # Check if MADS is available and enabled for longitudinal control
+    mads_enabled_long = (self.sm.valid['selfdriveStateSP'] and 
+                         self.sm['selfdriveStateSP'].mads.available and 
+                         self.sm['selfdriveStateSP'].mads.enabled)
+    self.v_cruise_helper.update_v_cruise(CS, self.sm['carControl'].enabled, self.is_metric, mads_enabled_long)
     if self.sm['carControl'].enabled and not self.CC_prev.enabled:
       # Use CarState w/ buttons from the step selfdrived enables on
       self.v_cruise_helper.initialize_v_cruise(self.CS_prev, self.experimental_mode, self.dynamic_experimental_control)

--- a/selfdrive/car/cruise.py
+++ b/selfdrive/car/cruise.py
@@ -43,10 +43,11 @@ class VCruiseHelper(VCruiseHelperSP):
   def v_cruise_initialized(self):
     return self.v_cruise_kph != V_CRUISE_UNSET
 
-  def update_v_cruise(self, CS, enabled, is_metric):
+  def update_v_cruise(self, CS, enabled, is_metric, mads_enabled_long=False):
     self.v_cruise_kph_last = self.v_cruise_kph
 
-    if CS.cruiseState.available:
+    # Allow cruise control updates if cruise is available OR MADS is enabled for longitudinal control
+    if CS.cruiseState.available or mads_enabled_long:
       if not self.CP.pcmCruise:
         # if stock cruise is completely disabled, then we can use our own set speed logic
         self._update_v_cruise_non_pcm(CS, enabled, is_metric)

--- a/selfdrive/car/tests/test_cruise_speed.py
+++ b/selfdrive/car/tests/test_cruise_speed.py
@@ -55,7 +55,7 @@ class TestVCruiseHelper:
   def reset_cruise_speed_state(self):
     # Two resets previous cruise speed
     for _ in range(2):
-      self.v_cruise_helper.update_v_cruise(car.CarState(cruiseState={"available": False}), enabled=False, is_metric=False)
+      self.v_cruise_helper.update_v_cruise(car.CarState(cruiseState={"available": False}), enabled=False, is_metric=False, mads_enabled_long=False)
 
   def enable(self, v_ego, experimental_mode, dynamic_experimental_control):
     # Simulates user pressing set with a current speed
@@ -73,7 +73,7 @@ class TestVCruiseHelper:
         CS = car.CarState(cruiseState={"available": True})
         CS.buttonEvents = [ButtonEvent(type=btn, pressed=pressed)]
 
-        self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=False)
+        self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=False, mads_enabled_long=False)
         assert pressed == (self.v_cruise_helper.v_cruise_kph == self.v_cruise_helper.v_cruise_kph_last)
 
   def test_rising_edge_enable(self):
@@ -88,7 +88,7 @@ class TestVCruiseHelper:
                              (True, False)):
       CS = car.CarState(cruiseState={"available": True})
       CS.buttonEvents = [ButtonEvent(type=ButtonType.decelCruise, pressed=pressed)]
-      self.v_cruise_helper.update_v_cruise(CS, enabled=enabled, is_metric=False)
+      self.v_cruise_helper.update_v_cruise(CS, enabled=enabled, is_metric=False, mads_enabled_long=False)
       if pressed:
         self.enable(V_CRUISE_INITIAL * CV.KPH_TO_MS, False, False)
 
@@ -106,7 +106,7 @@ class TestVCruiseHelper:
       for pressed in (True, False):
         CS = car.CarState(cruiseState={"available": True, "standstill": standstill})
         CS.buttonEvents = [ButtonEvent(type=ButtonType.accelCruise, pressed=pressed)]
-        self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=False)
+        self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=False, mads_enabled_long=False)
 
         # speed should only update if not at standstill and button falling edge
         should_equal = standstill or pressed

--- a/sunnypilot/selfdrive/car/tests/test_custom_cruise.py
+++ b/sunnypilot/selfdrive/car/tests/test_custom_cruise.py
@@ -29,24 +29,24 @@ class TestCustomAccIncrements(TestVCruiseHelper):
     """Simulate a short button press (press + release)"""
     CS = car.CarState(cruiseState={"available": True})
     CS.buttonEvents = [ButtonEvent(type=button_type, pressed=True)]
-    self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=True)
+    self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=True, mads_enabled_long=False)
 
     CS.buttonEvents = [ButtonEvent(type=button_type, pressed=False)]
-    self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=True)
+    self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=True, mads_enabled_long=False)
 
   def press_button_long(self, button_type: car.CarState.ButtonEvent.Type) -> None:
     """Simulate a long button press (50+ frames)"""
     CS = car.CarState(cruiseState={"available": True})
     CS.buttonEvents = [ButtonEvent(type=button_type, pressed=True)]
-    self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=True)
+    self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=True, mads_enabled_long=False)
 
     # Hold for 50 frames to trigger long press
     CS.buttonEvents = []
     for _ in range(50):
-      self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=True)
+      self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=True, mads_enabled_long=False)
 
     CS.buttonEvents = [ButtonEvent(type=button_type, pressed=False)]
-    self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=True)
+    self.v_cruise_helper.update_v_cruise(CS, enabled=True, is_metric=True, mads_enabled_long=False)
 
   def set_custom_increments(self, enabled: bool, short_inc: int, long_inc: int) -> None:
     """Set custom ACC increment parameters"""


### PR DESCRIPTION
<!--- ***** Template: Bugfix *****

**Description**

Fixes an issue where speed control buttons were non-functional when MADS (Modified Assist Driving System) was engaged without stock Smart Cruise Control (SCC). Previously, `VCruiseHelper.update_v_cruise` would ignore button presses if `CS.cruiseState.available` was `False`, which occurs when stock SCC is not active. This prevented longitudinal control adjustments via buttons even when MADS was active and intended to provide control.

The fix modifies `VCruiseHelper.update_v_cruise` to also process speed button inputs when MADS is enabled for longitudinal control, ensuring that MADS behaves like experimental mode for speed control regardless of stock SCC availability.

**Verification**

The changes were verified by ensuring successful compilation and passing existing unit tests. On-road testing with MADS engaged on a vehicle without stock SCC is recommended to confirm full functionality of speed control buttons.

-->

---
<a href="https://cursor.com/background-agent?bcId=bc-a99eb01f-7de0-4ff1-bcf7-7fc290b81fe1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a99eb01f-7de0-4ff1-bcf7-7fc290b81fe1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

