### PR TITLE
Investigate speed control warning in Mads mode

### DIFF
--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -216,10 +216,21 @@ class Car:
     if can_rcv_valid and REPLAY:
       self.can_log_mono_time = messaging.log_from_bytes(can_strs[0]).logMonoTime
 
-    self.v_cruise_helper.update_v_cruise(CS, self.sm['carControl'].enabled, self.is_metric)
+    # Determine if MADS is providing longitudinal control (treat like experimental)
+    mads_long_enabled = False
+    try:
+      ss_sp = self.sm['selfdriveStateSP'] if 'selfdriveStateSP' in self.sm else None
+      if ss_sp is not None and getattr(ss_sp.mads, 'available', False):
+        mads_long_enabled = bool(getattr(ss_sp.mads, 'enabled', False))
+    except Exception:
+      mads_long_enabled = False
+
+    self.v_cruise_helper.update_v_cruise(CS, self.sm['carControl'].enabled, self.is_metric, mads_long_enabled)
     if self.sm['carControl'].enabled and not self.CC_prev.enabled:
       # Use CarState w/ buttons from the step selfdrived enables on
-      self.v_cruise_helper.initialize_v_cruise(self.CS_prev, self.experimental_mode, self.dynamic_experimental_control)
+      # Treat MADS-enabled longitudinal like experimental for initial set speed
+      initial_exp = self.experimental_mode or mads_long_enabled
+      self.v_cruise_helper.initialize_v_cruise(self.CS_prev, initial_exp, self.dynamic_experimental_control)
 
     # TODO: mirror the carState.cruiseState struct?
     CS.vCruise = float(self.v_cruise_helper.v_cruise_kph)

--- a/selfdrive/car/cruise.py
+++ b/selfdrive/car/cruise.py
@@ -43,16 +43,19 @@ class VCruiseHelper(VCruiseHelperSP):
   def v_cruise_initialized(self):
     return self.v_cruise_kph != V_CRUISE_UNSET
 
-  def update_v_cruise(self, CS, enabled, is_metric):
+  def update_v_cruise(self, CS, enabled, is_metric, mads_long_enabled: bool = False):
     self.v_cruise_kph_last = self.v_cruise_kph
 
-    if CS.cruiseState.available:
-      if not self.CP.pcmCruise:
-        # if stock cruise is completely disabled, then we can use our own set speed logic
-        self._update_v_cruise_non_pcm(CS, enabled, is_metric)
-        self.v_cruise_cluster_kph = self.v_cruise_kph
-        self.update_button_timers(CS, enabled)
-      else:
+    # Treat MADS-enabled longitudinal as non-PCM so we manage set speed internally
+    use_non_pcm = (not self.CP.pcmCruise) or bool(mads_long_enabled)
+
+    if use_non_pcm:
+      # Use internal logic regardless of stock cruise availability
+      self._update_v_cruise_non_pcm(CS, enabled, is_metric)
+      self.v_cruise_cluster_kph = self.v_cruise_kph
+      self.update_button_timers(CS, enabled)
+    else:
+      if CS.cruiseState.available:
         self.v_cruise_kph = CS.cruiseState.speed * CV.MS_TO_KPH
         self.v_cruise_cluster_kph = CS.cruiseState.speedCluster * CV.MS_TO_KPH
         if CS.cruiseState.speed == 0:
@@ -61,9 +64,9 @@ class VCruiseHelper(VCruiseHelperSP):
         elif CS.cruiseState.speed == -1:
           self.v_cruise_kph = -1
           self.v_cruise_cluster_kph = -1
-    else:
-      self.v_cruise_kph = V_CRUISE_UNSET
-      self.v_cruise_cluster_kph = V_CRUISE_UNSET
+      else:
+        self.v_cruise_kph = V_CRUISE_UNSET
+        self.v_cruise_cluster_kph = V_CRUISE_UNSET
 
   def _update_v_cruise_non_pcm(self, CS, enabled, is_metric):
     # handle button presses. TODO: this should be in state_control, but a decelCruise press


### PR DESCRIPTION
<!--- ***** Template: Bugfix *****

**Description**

Fixes an issue where pressing the speed control button with MADS engaged (without SCC) resulted in a "not available" warning. Previously, the system did not treat MADS-enabled longitudinal control as a non-PCM mode for speed adjustments. This PR updates `VCruiseHelper` to allow internal speed control when MADS is active, and ensures the set speed is initialized correctly upon MADS engagement, mirroring experimental mode behavior.

**Verification**

- Syntax check passed.
- On-road verification needed: With MADS ON and experimental mode OFF, confirm that pressing +/- adjusts the set speed, the HUD updates, and the car respects longitudinal targets.

-->

---
<a href="https://cursor.com/background-agent?bcId=bc-53fdfb2d-3323-460d-8b61-04f53322c5f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-53fdfb2d-3323-460d-8b61-04f53322c5f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

